### PR TITLE
add continuous integration checks

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,17 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Siphon image
+      run:  docker build . --file Dockerfile.passenger --tag siphon-ruby:$(date +%s)
+    - name: Build the Siphon Database Docker image
+      run:  docker build . --file Dockerfile.mysql --tag siphon-db:$(date +%s)

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,64 @@
+name: Ruby CI
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.4, 2.5, 2.6]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+      # uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Start mysql
+      run: sudo systemctl start mysql.service
+    - name: Install bundler
+      run: gem install bundler:1.17.3
+    - name: Install dependencies
+      run: bundle install
+    - name: Pre-test steps
+      env:
+        MYSQL_PASSWORD: root
+        database_password: db_password
+        MYSQL_ROOT_PASSWORD: root
+        database_host: db_host
+        database_name: siphon_test
+        database_username: siphon_test_dba
+        auth_server_id: auth_server_id
+        base_auth_url: base_auth_url
+        client_id: client_id
+        client_secret: client_secret
+        HOST_NAME: localhost
+        SECRET_KEY_BASE: secret_key_base
+      run: |
+        cp config/secrets.yml.template config/secrets.yml
+        cp config/database.yml.template config/database.yml
+        mysql -uroot -p$MYSQL_PASSWORD -e 'create database siphon_test'
+        RAILS_ENV=test bundle exec rake --trace db:migrate test
+    - name: Run tests
+      env:
+        MYSQL_PASSWORD: root
+        database_password: db_password
+        MYSQL_ROOT_PASSWORD: root
+        database_host: db_host
+        database_name: siphon_test
+        database_username: siphon_test_dba
+        auth_server_id: auth_server_id
+        base_auth_url: base_auth_url
+        client_id: client_id
+        client_secret: client_secret
+        HOST_NAME: localhost
+        SECRET_KEY_BASE: secret_key_base
+      run: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
-# Siphon Hesburgh Libraries Reformatting Books.  This code is for the docker images and local builds.  The infrastructure code CI/CD needed to run in AWS is available at https://github.com/ndlib/cdk-siphon
+# Siphon Hesburgh Libraries Reformatting Books  
 
-# Docker Instructions
+This code is for the docker images and local builds.  The infrastructure code CI/CD needed to run in AWS is available at [ndlib/cdk-siphon](https://github.com/ndlib/cdk-siphon)
 
-## When running docker locally
+## Docker Instructions
+
+### When running docker locally
+
 Local builds will use mysql image whereas AWS uses RDS and variable values come from parameter store.
-```
 
 You can also change the ENV variables values for the docker images. Modify the .env file and populate it with passwords needed to create the MySQL database, access the database, etc. The file should look something like the following:
 
+```console
 DB_PASSWORD=db_password
 MYSQL_ROOT_PASSWORD=mysql_root_password
 DB_HOST=db_host
@@ -21,11 +24,14 @@ HOST_NAME=localhost
 SECRET_KEY_BASE=secret_key_base
 ```
 
-## When running out of AWS
-Please see cdk-siphon repository (https://github.com/ndlib/cdk-siphon) for AWS infrastructure code which uses this repo to build container images.
+### When running out of AWS
+
+Please see cdk-siphon repository [ndlib/cdk-siphon](https://github.com/ndlib/cdk-siphon) for AWS infrastructure code which uses this repo to build container images.
 
 ## Running
+
 To run the full stack of services using docker-compose:
+
 ```sh
 docker-compose -f "docker-compose.yml" up -d --build
 ```

--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -25,6 +25,8 @@ test: &test
   <<: *mysql_settings
   database: siphon_test
   username: root
+  host: localhost
+  password: <%= ENV["MYSQL_PASSWORD"] %>
 
 pre_production:
   <<: *mysql_settings

--- a/config/secrets.yml.template
+++ b/config/secrets.yml.template
@@ -38,3 +38,13 @@ development:
      org: nd
      base_auth_url: https://nd.okta.com/oauth2/
      redirect_url: https://{{ host_name }}/users/auth/oktaoauth/callback
+test:
+  secret_key_base: "123456789"
+  okta:  
+    auth_server_id: <%= ENV["auth_server_id"] %>
+    client_id: <%= ENV["client_id"] %>
+    client_secret: <%= ENV["client_secret"] %>
+    domain: okta
+    org: nd
+    base_auth_url: https://nd.okta.com/oauth2/
+    redirect_url: https://localhost:3000/users/auth/oktaoauth/callback


### PR DESCRIPTION
This PR adds GitHub Actions for two checks:

- [x] Ensuring that the Docker images used will still build successfully

- [x] Run the ruby test suite via `rspec`

There are a few changes to other files, including making the README a little easier to read.